### PR TITLE
Refactor: 응답 객체 키 네이밍을 camelCase로 변경

### DIFF
--- a/src/movie/dto/find-movie-detail-response.dto.ts
+++ b/src/movie/dto/find-movie-detail-response.dto.ts
@@ -22,19 +22,19 @@ export class FindMovieDetailResponseDto {
     description: '영화 포스터 이미지 경로',
     example: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
   })
-  poster_path: string;
+  posterPath: string;
 
   @ApiProperty({
     description: '영화 배경 이미지 경로',
     example: '/uIpJPDNFoeX0TVml9smPrs9KUVx.jpg',
   })
-  backdrop_path: string;
+  backdropPath: string;
 
   @ApiProperty({ description: '성인 관람가 여부', example: false })
   adult: boolean;
 
   @ApiProperty({ description: '원본 언어', example: 'en' })
-  original_language: string;
+  originalLanguage: string;
 
   @ApiProperty({
     description: '영화 장르 목록',
@@ -66,30 +66,30 @@ export class FindMovieDetailResponseDto {
   popularity: number;
 
   @ApiProperty({ description: '개봉일 (YYYY-MM-DD)', example: '2025-05-14' })
-  release_date: string;
+  releaseDate: string;
 
   @ApiProperty({ description: '평균 평점', example: 7.219 })
-  vote_average: number;
+  voteAverage: number;
 
   @ApiProperty({ description: '투표 수', example: 1147 })
-  vote_count: number;
+  voteCount: number;
 
   static of(raw: TMDBMovieDetailResponse): FindMovieDetailResponseDto {
     return {
       id: raw.id,
       title: raw.title,
       overview: raw.overview,
-      poster_path: raw.poster_path,
-      backdrop_path: raw.backdrop_path,
+      posterPath: raw.poster_path,
+      backdropPath: raw.backdrop_path,
       adult: raw.adult,
-      original_language: raw.original_language,
+      originalLanguage: raw.original_language,
       genres: raw.genres,
       status: raw.status,
       runtime: raw.runtime,
       popularity: raw.popularity,
-      release_date: raw.release_date,
-      vote_average: raw.vote_average,
-      vote_count: raw.vote_count,
+      releaseDate: raw.release_date,
+      voteAverage: raw.vote_average,
+      voteCount: raw.vote_count,
     };
   }
 }

--- a/src/movie/dto/find-movie-list-response.dto.ts
+++ b/src/movie/dto/find-movie-list-response.dto.ts
@@ -9,10 +9,10 @@ export class FindMovieListResponseDto {
     example: [
       {
         id: 157336,
-        posterUrl: '/example.jpg',
+        posterPath: '/example.jpg',
         title: '영화이름1',
       },
-      { id: 123456, posterUrl: '/abc.jpg', title: '영화이름2' },
+      { id: 123456, posterPath: '/abc.jpg', title: '영화이름2' },
     ],
   })
   movies: MovieListItemDto[];

--- a/src/movie/dto/movie-list-item.dto.ts
+++ b/src/movie/dto/movie-list-item.dto.ts
@@ -15,13 +15,13 @@ export class MovieListItemDto {
     description: '영화 포스터 이미지 URL',
     example: '/example.jpg',
   })
-  poster_path: string;
+  posterPath: string;
 
   static of(this: void, raw: TMDBMovie): MovieListItemDto {
     return {
       id: raw.id,
       title: raw.title,
-      poster_path: raw.poster_path,
+      posterPath: raw.poster_path,
     };
   }
 }

--- a/src/tv/dto/find-tv-detail-response.dto.ts
+++ b/src/tv/dto/find-tv-detail-response.dto.ts
@@ -18,23 +18,23 @@ export class FindTvDetailResponseDto {
 
   @ApiProperty({ nullable: true })
   @IsOptional()
-  poster_path: string | null;
+  posterPath: string | null;
 
   @ApiProperty({ nullable: true })
   @IsOptional()
-  backdrop_path: string | null;
+  backdropPath: string | null;
 
   @ApiProperty()
   adult: boolean;
 
   @ApiProperty()
-  original_language: string;
+  originalLanguage: string;
 
   @ApiProperty({ type: [String] })
   languages: string[];
 
   @ApiProperty()
-  in_production: boolean;
+  inProduction: boolean;
 
   @ApiProperty({ type: [Object] })
   genres: { id: number; name: string }[];
@@ -44,38 +44,38 @@ export class FindTvDetailResponseDto {
 
   @ApiProperty({ nullable: true })
   @IsOptional()
-  first_air_date: string | null;
+  firstAirDate: string | null;
 
   @ApiProperty({ nullable: true })
   @IsOptional()
-  last_air_date: string | null;
+  lastAirDate: string | null;
 
   @ApiProperty()
   popularity: number;
 
   @ApiProperty()
-  vote_average: number;
+  voteAverage: number;
 
   @ApiProperty()
-  vote_count: number;
+  voteCount: number;
 
   @ApiProperty()
-  number_of_seasons: number;
+  numberOfSeasons: number;
 
   @ApiProperty()
-  number_of_episodes: number;
+  numberOfEpisodes: number;
 
   @ApiProperty({ type: [Object] })
   @IsArray()
   seasons: {
     id: number;
-    season_number: number;
-    episode_count: number;
-    poster_path: string | null;
-    air_date: string | null;
+    seasonNumber: number;
+    episodeCount: number;
+    posterPath: string | null;
+    airDate: string | null;
     name: string;
     title: string;
-    vote_average: number;
+    voteAverage: number;
   }[];
 
   // TMDB 응답 객체 -> FindTvDetailResponseDto 변환 메서드
@@ -84,30 +84,30 @@ export class FindTvDetailResponseDto {
       id: raw.id,
       title: raw.name,
       overview: raw.overview,
-      poster_path: raw.poster_path,
-      backdrop_path: raw.backdrop_path,
+      posterPath: raw.poster_path,
+      backdropPath: raw.backdrop_path,
       adult: raw.adult,
-      original_language: raw.original_language,
+      originalLanguage: raw.original_language,
       languages: raw.languages,
-      in_production: raw.in_production,
+      inProduction: raw.in_production,
       genres: raw.genres.map((g: TMDBGenre) => ({ id: g.id, name: g.name })),
       status: raw.status,
-      first_air_date: raw.first_air_date,
-      last_air_date: raw.last_air_date,
+      firstAirDate: raw.first_air_date,
+      lastAirDate: raw.last_air_date,
       popularity: raw.popularity,
-      vote_average: raw.vote_average,
-      vote_count: raw.vote_count,
-      number_of_seasons: raw.number_of_seasons,
-      number_of_episodes: raw.number_of_episodes,
+      voteAverage: raw.vote_average,
+      voteCount: raw.vote_count,
+      numberOfSeasons: raw.number_of_seasons,
+      numberOfEpisodes: raw.number_of_episodes,
       seasons: raw.seasons.map((s: TMDBTvSeason) => ({
         id: s.id,
-        season_number: s.season_number,
-        episode_count: s.episode_count,
-        poster_path: s.poster_path,
-        air_date: s.air_date,
+        seasonNumber: s.season_number,
+        episodeCount: s.episode_count,
+        posterPath: s.poster_path,
+        airDate: s.air_date,
         name: s.name,
         title: s.name,
-        vote_average: s.vote_average,
+        voteAverage: s.vote_average,
       })),
     };
   }

--- a/src/tv/dto/find-tv-list-response.dto.ts
+++ b/src/tv/dto/find-tv-list-response.dto.ts
@@ -11,12 +11,12 @@ export class FindTvListResponseDto {
     example: [
       {
         id: 1396,
-        poster_path: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
+        posterPath: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
         title: '브레이킹 배드',
       },
       {
         id: 1398,
-        poster_path: '/rTc7ZXdroqjkKivFPvCPX0Ru7uw.jpg',
+        posterPath: '/rTc7ZXdroqjkKivFPvCPX0Ru7uw.jpg',
         title: '더 소프라노스',
       },
     ],

--- a/src/tv/dto/tv-list-item.dto.ts
+++ b/src/tv/dto/tv-list-item.dto.ts
@@ -9,13 +9,13 @@ export class TvListItemDto {
   title: string;
 
   @ApiProperty({ description: '포스터 경로', example: '/example.jpg' })
-  poster_path: string;
+  posterPath: string;
 
   static of(raw: TMDBTvItem): TvListItemDto {
     return {
       id: raw.id,
       title: raw.name,
-      poster_path: raw.poster_path,
+      posterPath: raw.poster_path,
     };
   }
 }


### PR DESCRIPTION
Closes #28 

## 개요

- 영화, TV 시리즈 Response snake_case에서 camelCase로 전략 변경

## 작업사항

- 영화 조회 API의 응답 key를 snake_case에서 camelCase로 변경했습니다
- TV 시리즈 조회 API의 응답 key를 snake_case에서 camelCase로 변경했습니다
