### PR TITLE
Fix: useImportType 규칙 해제

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useImportType": "off"
+      }
     }
   },
   "javascript": {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import type { AppService } from './app.service';
+import { AppService } from './app.service';
 
 @Controller()
 export class AppController {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,16 +19,16 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import type { Response } from 'express';
+import { Response } from 'express';
 import * as ms from 'ms';
 import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
 import { setTokenCookie } from 'src/common/utils/cookie.util';
-import type { CreateUserRequestDto } from 'src/user/dto/request/create-user-request.dto';
+import { CreateUserRequestDto } from 'src/user/dto/request/create-user-request.dto';
 import { UniqueNicknameGenerationException } from 'src/user/exceptions/unique-nickname-generation.exception';
-import type { UserService } from 'src/user/user.service';
+import { UserService } from 'src/user/user.service';
 import { DuplicateNicknameException } from '../user/exceptions/duplicate-nickname.exception';
 import { UserNotFoundException } from '../user/exceptions/user-not-found.exception';
-import type { AuthService } from './auth.service';
+import { AuthService } from './auth.service';
 import { Public } from './decorators/public.decorator';
 import { LoginRequestDto } from './dto/request/login-request.dto';
 import { UpdatePasswordRequestDto } from './dto/request/update-password-request.dto';
@@ -44,7 +44,7 @@ import { KakaoAuthGuard } from './guards/kakao-auth/kakao-auth.guard';
 import { LocalAuthGuard } from './guards/local-auth/local-auth.guard';
 import { LocalUserOnlyGuard } from './guards/local-auth/local-user-only.guard';
 import { RefreshAuthGuard } from './guards/refresh-auth/refresh-auth.guard';
-import type { RequestWithUser } from './types/request-with-user.interface';
+import { RequestWithUser } from './types/request-with-user.interface';
 
 @ApiTags('Auth')
 @Controller('auth')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,18 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common';
-import type { ConfigType } from '@nestjs/config';
-import type { JwtService } from '@nestjs/jwt';
+import { ConfigType } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import * as argon2 from 'argon2';
 import * as bcrypt from 'bcrypt';
 import { compare } from 'bcrypt';
-import type Redis from 'ioredis';
-import type { CreateUserRequestDto } from 'src/user/dto/request/create-user-request.dto';
-import type { AuthProvider } from 'src/user/enums/auth-provider.enum';
-import type { UserRepository } from 'src/user/user.repository';
-import type { UserService } from 'src/user/user.service';
+import Redis from 'ioredis';
+import { CreateUserRequestDto } from 'src/user/dto/request/create-user-request.dto';
+import { AuthProvider } from 'src/user/enums/auth-provider.enum';
+import { UserRepository } from 'src/user/user.repository';
+import { UserService } from 'src/user/user.service';
 import { UserNotFoundException } from '../user/exceptions/user-not-found.exception';
 import refreshJwtConfig from './config/refresh-jwt.config';
-import type { UpdatePasswordRequestDto } from './dto/request/update-password-request.dto';
-import type { TokenResponse } from './dto/response/token-response.interface';
+import { UpdatePasswordRequestDto } from './dto/request/update-password-request.dto';
+import { TokenResponse } from './dto/response/token-response.interface';
 import { AlreadyRegisteredAccountException } from './exceptions/already-registered-account.exception';
 import { InvalidCredentialsException } from './exceptions/invalid-credentials.exception';
 import { InvalidCurrentPasswordException } from './exceptions/invalid-current-password.exception';
@@ -20,7 +20,7 @@ import { InvalidRefreshTokenException } from './exceptions/invalid-refresh-token
 import { OAuthAccountLoginException } from './exceptions/oauth-account-login.exception';
 import { OAuthAccountPasswordChangeException } from './exceptions/oauth-account-password-change.exception';
 import { PasswordMismatchException } from './exceptions/password-mismatch.exception';
-import type { AuthJwtPayload } from './types/auth-jwt-payload';
+import { AuthJwtPayload } from './types/auth-jwt-payload';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/guards/jwt-auth/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth/jwt-auth.guard.ts
@@ -1,5 +1,5 @@
-import { type ExecutionContext, Injectable } from '@nestjs/common';
-import type { Reflector } from '@nestjs/core';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from '../../decorators/public.decorator';
 

--- a/src/auth/guards/local-auth/local-user-only.guard.ts
+++ b/src/auth/guards/local-auth/local-user-only.guard.ts
@@ -1,11 +1,7 @@
-import {
-  type CanActivate,
-  type ExecutionContext,
-  Injectable,
-} from '@nestjs/common';
-import type { RequestWithUser } from 'src/auth/types/request-with-user.interface';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { RequestWithUser } from 'src/auth/types/request-with-user.interface';
 import { AuthProvider } from 'src/user/enums/auth-provider.enum';
-import type { UserRepository } from 'src/user/user.repository';
+import { UserRepository } from 'src/user/user.repository';
 
 @Injectable()
 export class LocalUserOnlyGuard implements CanActivate {

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
-import type { ConfigType } from '@nestjs/config';
+import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import { type Profile, Strategy } from 'passport-google-oauth20';
+import { Profile, Strategy } from 'passport-google-oauth20';
 import { AuthProvider } from 'src/user/enums/auth-provider.enum';
-import type { UserService } from 'src/user/user.service';
-import type { AuthService } from '../auth.service';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from '../auth.service';
 import googleOauthConfig from '../config/google-oauth.config';
 import { GoogleEmailNotFoundException } from '../exceptions/google-email-not-found.exception';
 import { StrategyConfigException } from '../exceptions/strategy-config.exception';
@@ -35,7 +35,11 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(accessToken: string, refreshToken: string, profile: Profile) {
+  async validate(
+    _accessToken: string,
+    _refreshTokenn: string,
+    profile: Profile,
+  ) {
     const { emails, name } = profile;
 
     if (!emails || emails.length === 0) {

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,11 +1,11 @@
 import { Inject, Injectable } from '@nestjs/common';
-import type { ConfigType } from '@nestjs/config';
+import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import type { Request } from 'express';
+import { Request } from 'express';
 import { Strategy } from 'passport-jwt';
 import jwtConfig from '../config/jwt.config';
 import { StrategyConfigException } from '../exceptions/strategy-config.exception';
-import type { AuthJwtPayload } from '../types/auth-jwt-payload';
+import { AuthJwtPayload } from '../types/auth-jwt-payload';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,14 +1,14 @@
 import { Inject, Injectable } from '@nestjs/common';
-import type { ConfigType } from '@nestjs/config';
+import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import { type Profile, Strategy } from 'passport-kakao';
+import { Profile, Strategy } from 'passport-kakao';
 import { AuthProvider } from 'src/user/enums/auth-provider.enum';
-import type { UserService } from 'src/user/user.service';
-import type { AuthService } from '../auth.service';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from '../auth.service';
 import kakaoOauthConfig from '../config/kakao-oauth.config';
 import { KakaoEmailNotFoundException } from '../exceptions/kakao-email-not-found.exception';
 import { StrategyConfigException } from '../exceptions/strategy-config.exception';
-import type {
+import {
   KakaoAccount,
   KakaoProfileResponse,
 } from '../interfaces/kakao.interface';
@@ -34,7 +34,11 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     });
   }
 
-  async validate(accessToken: string, refreshToken: string, profile: Profile) {
+  async validate(
+    _accessToken: string,
+    _refreshTokenn: string,
+    profile: Profile,
+  ) {
     console.log(profile);
     const response = profile._json as KakaoProfileResponse;
     const kakaoAccount = response.kakao_account;

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
-import type { AuthService } from '../auth.service';
+import { AuthService } from '../auth.service';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {

--- a/src/auth/strategies/refresh.strategy.ts
+++ b/src/auth/strategies/refresh.strategy.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
-import type { ConfigType } from '@nestjs/config';
+import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import type { Request } from 'express';
+import { Request } from 'express';
 import { Strategy } from 'passport-jwt';
-import type { AuthService } from '../auth.service';
+import { AuthService } from '../auth.service';
 import refreshJwtConfig from '../config/refresh-jwt.config';
 import { StrategyConfigException } from '../exceptions/strategy-config.exception';
-import type { AuthJwtPayload } from '../types/auth-jwt-payload';
+import { AuthJwtPayload } from '../types/auth-jwt-payload';
 
 @Injectable()
 export class RefreshJwtStrategy extends PassportStrategy(

--- a/src/auth/types/request-with-user.interface.ts
+++ b/src/auth/types/request-with-user.interface.ts
@@ -1,4 +1,4 @@
-import type { Request } from 'express';
+import { Request } from 'express';
 
 interface UserPayload {
   id: number;

--- a/src/genre/genre.controller.ts
+++ b/src/genre/genre.controller.ts
@@ -12,8 +12,8 @@ import { ContentNotFoundException } from 'src/common/exceptions/content-not-foun
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth/jwt-auth.guard';
 import { ContentType } from '../common/types/content-type.enum';
-import type { GenreListResponseDto } from './dto/genre-list-response.dto';
-import type { GenreService } from './genre.service';
+import { GenreListResponseDto } from './dto/genre-list-response.dto';
+import { GenreService } from './genre.service';
 
 @ApiTags('Genres')
 @ApiBearerAuth()

--- a/src/genre/genre.repository.ts
+++ b/src/genre/genre.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import type { ContentType } from 'src/common/types/content-type.enum';
-import type { Repository } from 'typeorm';
-import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
-import type { TMDBGenre } from '../common/interfaces/tmdb-common.interface';
+import { ContentType } from 'src/common/types/content-type.enum';
+import { Repository } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { TMDBGenre } from '../common/interfaces/tmdb-common.interface';
 import { Genre } from './entity/genre.entity';
 import { mapGenreToEmoji } from './utils/genre-emoji-mapper.util';
 

--- a/src/genre/genre.service.ts
+++ b/src/genre/genre.service.ts
@@ -1,12 +1,12 @@
-import type { HttpService } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { ContentType } from './../common/types/content-type.enum';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
 import { GenreListResponseDto } from './dto/genre-list-response.dto';
-import type { GenreRepository } from './genre.repository';
-import type { TMDBGenreListResponse } from './interfaces/genre.interface';
+import { GenreRepository } from './genre.repository';
+import { TMDBGenreListResponse } from './interfaces/genre.interface';
 import { mapGenreToEmoji } from './utils/genre-emoji-mapper.util';
 
 @Injectable()

--- a/src/movie/movie.controller.ts
+++ b/src/movie/movie.controller.ts
@@ -11,9 +11,9 @@ import { ContentNotFoundException } from 'src/common/exceptions/content-not-foun
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { InvalidGenreIdException } from 'src/common/exceptions/invalid-genre-id.exception';
 import { InvalidPageException } from 'src/common/exceptions/invalid-page.exception';
-import type { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
-import type { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
-import type { MovieService } from './movie.service';
+import { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
+import { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
+import { MovieService } from './movie.service';
 
 @Controller('movies')
 @ApiTags('Movies')

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -1,12 +1,12 @@
-import type { HttpService } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
 import { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
 import { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
-import type { TMDBMovieDetailResponse } from './interfaces/movie.interface';
-import type { TMDBNowPlayingResponse } from './interfaces/movie-list.interface';
+import { TMDBMovieDetailResponse } from './interfaces/movie.interface';
+import { TMDBNowPlayingResponse } from './interfaces/movie-list.interface';
 
 @Injectable()
 export class MovieService {

--- a/src/tv/tv.controller.ts
+++ b/src/tv/tv.controller.ts
@@ -11,9 +11,9 @@ import { ContentNotFoundException } from 'src/common/exceptions/content-not-foun
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { InvalidGenreIdException } from 'src/common/exceptions/invalid-genre-id.exception';
 import { InvalidPageException } from 'src/common/exceptions/invalid-page.exception';
-import type { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
-import type { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
-import type { TvService } from './tv.service';
+import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
+import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
+import { TvService } from './tv.service';
 
 @Controller('tvs')
 @ApiTags('Tvs')

--- a/src/tv/tv.service.ts
+++ b/src/tv/tv.service.ts
@@ -1,12 +1,12 @@
-import type { HttpService } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
 import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
 import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
-import type { TMDBTvDetailResponse } from './interfaces/tv.interface';
-import type { TMDBTvListResponse } from './interfaces/tv-list.interface';
+import { TMDBTvDetailResponse } from './interfaces/tv.interface';
+import { TMDBTvListResponse } from './interfaces/tv-list.interface';
 
 @Injectable()
 export class TvService {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -8,11 +8,11 @@ import {
 } from '@nestjs/swagger';
 import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
 import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
-import type { RequestWithUser } from '../auth/types/request-with-user.interface';
+import { RequestWithUser } from '../auth/types/request-with-user.interface';
 import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
 import { UserResponseDto } from './dto/response/user-response.dto';
 import { DuplicateNicknameException } from './exceptions/duplicate-nickname.exception';
-import type { UserService } from './user.service';
+import { UserService } from './user.service';
 
 @ApiCookieAuth('accessToken')
 @ApiTags('User')

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
-import type { Repository } from 'typeorm';
-import type { CreateUserRequestDto } from './dto/request/create-user-request.dto';
-import type { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
+import { Repository } from 'typeorm';
+import { CreateUserRequestDto } from './dto/request/create-user-request.dto';
+import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
 import { User } from './user.entity';
 
 @Injectable()

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,13 +3,13 @@ import { plainToInstance } from 'class-transformer';
 import { AlreadyRegisteredAccountException } from 'src/auth/exceptions/already-registered-account.exception';
 import { generateRandomNickname } from 'src/common/utils/nickname.util';
 import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
-import type { CreateUserRequestDto } from './dto/request/create-user-request.dto';
-import type { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
+import { CreateUserRequestDto } from './dto/request/create-user-request.dto';
+import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
 import { UserResponseDto } from './dto/response/user-response.dto';
 import { DuplicateNicknameException } from './exceptions/duplicate-nickname.exception';
 import { UniqueNicknameGenerationException } from './exceptions/unique-nickname-generation.exception';
-import type { EmailDuplicateResult } from './types/user.types';
-import type { UserRepository } from './user.repository';
+import { EmailDuplicateResult } from './types/user.types';
+import { UserRepository } from './user.repository';
 
 @Injectable()
 export class UserService {


### PR DESCRIPTION
Closes #30 

## 개요

- Biome의 useImportType 규칙을 비활성화하여 NestJS의 의존성 주입(DI) 오류를 방지하고, 런타임 import가 필요한 클래스(DTO, Service, Repository 등)에 대해 모두 일반 import로 변경하였습니다.

## 작업사항

- biome.json에서 useImportType 규칙 비활성화 (`linter.rules.style.useImportType: "off"`)
- import type으로 처리되어 버린 서비스, 리포지토리, DTO 등 NestJS 런타임에서 필요한 클래스 import를 일반 import로 복구

## 주의사항

- NestJS의 DI, Validation 등 런타임에 필요한 클래스는 반드시 일반 import를 사용해야 하며, type import 사용 시 런타임 오류가 발생할 수 있습니다.
- 코드 리뷰 시 import 관련 변경 사항에 대해 한 번 더 확인 바랍니다.